### PR TITLE
Address fields should be dynamically generated

### DIFF
--- a/src/patient-registration/input/dummy-data/dummy-data-input.component.tsx
+++ b/src/patient-registration/input/dummy-data/dummy-data-input.component.tsx
@@ -21,12 +21,6 @@ export const dummyFormValues: FormValues = {
   monthsEstimated: 2,
   birthdateEstimated: true,
   telephoneNumber: '0800001066',
-  address1: 'Bom Jesus Street',
-  address2: '',
-  cityVillage: 'Recife',
-  stateProvince: 'Pernambuco',
-  country: 'Brazil',
-  postalCode: '50030-310',
 };
 
 export const DummyDataInput: React.FC<DummyDataInputProps> = ({ setValues }) => {

--- a/src/patient-registration/patient-registration-helper.tsx
+++ b/src/patient-registration/patient-registration-helper.tsx
@@ -5,15 +5,6 @@ interface NameValue {
   familyName: string;
 }
 
-interface AddressValue {
-  address1: string;
-  address2: string;
-  cityVillage: string;
-  stateProvince: string;
-  postalCode: string;
-  country: string;
-}
-
 interface AttributeValue {
   attributeType: string;
   value: string;
@@ -44,7 +35,7 @@ export type Patient = {
     birthdate: Date;
     birthdateEstimated: boolean;
     attributes: Array<AttributeValue>;
-    addresses: Array<AddressValue>;
+    addresses: Array<any>;
   };
 };
 

--- a/src/patient-registration/patient-registration-helper.tsx
+++ b/src/patient-registration/patient-registration-helper.tsx
@@ -35,7 +35,7 @@ export type Patient = {
     birthdate: Date;
     birthdateEstimated: boolean;
     attributes: Array<AttributeValue>;
-    addresses: Array<any>;
+    addresses: Array<Record<string, string>>;
   };
 };
 

--- a/src/patient-registration/patient-registration.component.tsx
+++ b/src/patient-registration/patient-registration.component.tsx
@@ -73,7 +73,6 @@ export const PatientRegistration: React.FC = () => {
   const [identifierTypes, setIdentifierTypes] = useState(new Array<PatientIdentifierType>());
   const [validationSchema, setValidationSchema] = useState(initialSchema);
   const [addressTemplate, setAddressTemplate] = useState('');
-  const [addressValidationSchema, setAddressValidationSchema] = useState(Yup.object({}));
 
   useEffect(() => {
     const abortController = new AbortController();
@@ -170,7 +169,7 @@ export const PatientRegistration: React.FC = () => {
       });
 
       Object.assign(initialFormValues, initialAddressFieldValues);
-      setAddressValidationSchema(addressValidationSchemaTmp);
+      setValidationSchema(validationSchema => validationSchema.concat(addressValidationSchemaTmp));
     }
   }, [addressTemplate]);
 
@@ -249,7 +248,7 @@ export const PatientRegistration: React.FC = () => {
     <main className={`omrs-main-content ${styles.main}`}>
       <Formik
         initialValues={initialFormValues}
-        validationSchema={validationSchema.concat(addressValidationSchema)}
+        validationSchema={validationSchema}
         onSubmit={(values, { setSubmitting }) => {
           onFormSubmit(values);
           setSubmitting(false);

--- a/src/patient-registration/patient-registration.component.tsx
+++ b/src/patient-registration/patient-registration.component.tsx
@@ -39,12 +39,6 @@ export interface FormValues {
   monthsEstimated: number;
   birthdateEstimated: boolean;
   telephoneNumber: string;
-  address1: string;
-  address2: string;
-  cityVillage: string;
-  stateProvince: string;
-  country: string;
-  postalCode: string;
 }
 
 export const initialFormValues: FormValues = {
@@ -62,13 +56,9 @@ export const initialFormValues: FormValues = {
   monthsEstimated: 0,
   birthdateEstimated: false,
   telephoneNumber: '',
-  address1: '',
-  address2: '',
-  cityVillage: '',
-  stateProvince: '',
-  country: '',
-  postalCode: '',
 };
+
+export const initialAddressFieldValues = {};
 
 interface AddressValidationSchemaType {
   name: string;
@@ -176,9 +166,10 @@ export const PatientRegistration: React.FC = () => {
       Array.prototype.forEach.call(nameMappings, nameMapping => {
         let name = nameMapping.getAttribute('name');
         let defaultValue = getValueIfItExists(name, 'elementDefaults', templateXmlDoc);
-        initialFormValues[name] = defaultValue ?? '';
+        initialAddressFieldValues[name] = defaultValue ?? '';
       });
 
+      Object.assign(initialFormValues, initialAddressFieldValues);
       setAddressValidationSchema(addressValidationSchemaTmp);
     }
   }, [addressTemplate]);
@@ -218,6 +209,10 @@ export const PatientRegistration: React.FC = () => {
         });
       }
     }
+    let addressObj = {};
+    Object.keys(initialAddressFieldValues).forEach(fieldName => {
+      addressObj[fieldName] = values[fieldName];
+    });
     const patient: Patient = {
       identifiers: identifiers,
       person: {
@@ -231,16 +226,7 @@ export const PatientRegistration: React.FC = () => {
             value: values.telephoneNumber,
           },
         ],
-        addresses: [
-          {
-            address1: values.address1,
-            address2: values.address2,
-            cityVillage: values.cityVillage,
-            stateProvince: values.stateProvince,
-            postalCode: values.postalCode,
-            country: values.country,
-          },
-        ],
+        addresses: [addressObj],
       },
     };
     savePatient(abortController, patient)

--- a/src/patient-registration/patient-registration.component.tsx
+++ b/src/patient-registration/patient-registration.component.tsx
@@ -209,9 +209,10 @@ export const PatientRegistration: React.FC = () => {
         });
       }
     }
-    let addressObj = {};
+
+    let addressFieldValues: Record<string, string> = {};
     Object.keys(initialAddressFieldValues).forEach(fieldName => {
-      addressObj[fieldName] = values[fieldName];
+      addressFieldValues[fieldName] = values[fieldName];
     });
     const patient: Patient = {
       identifiers: identifiers,
@@ -226,7 +227,7 @@ export const PatientRegistration: React.FC = () => {
             value: values.telephoneNumber,
           },
         ],
-        addresses: [addressObj],
+        addresses: [addressFieldValues],
       },
     };
     savePatient(abortController, patient)


### PR DESCRIPTION
Address fields are gotten from the backend through global properties and we cannot know at compile time which fields are available. In https://github.com/openmrs/openmrs-esm-patient-registration/pull/33, support for address template was added and this does not count on the definition of `FormValues`. This is a clean up PR for instances where address fields were still hardcoded.