### PR TITLE
MF-293: Actually use single-spa navigateToUrl

### DIFF
--- a/src/registration-link.tsx
+++ b/src/registration-link.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import singleSpaReact, { singleSpaNavigate } from 'single-spa-react';
+import singleSpaReact from 'single-spa-react';
+import { navigateToUrl } from 'single-spa';
 
 export default singleSpaReact({
   React,
@@ -12,7 +13,7 @@ export function RegistrationLink(props) {
   const className = `omrs-link omrs-filled-neutral`;
   const url = '/openmrs/spa/patient-registration';
   const button = (
-    <a className={className} href={url} onClick={event => singleSpaNavigate(event, url)}>
+    <a className={className} href={url} onClick={event => navigateToUrl(event, url)}>
       Patient Registration
     </a>
   );


### PR DESCRIPTION
The `registration-link` extension was not correctly set up for navigation. Per the initial configuration, it was trying to import `singleSpaNavigate` from `single-spa-react`. `singleSpaNavigate` does not have such an export. `single-spa` may have been using some fallback mechanism for navigating to the patient registration URL. This commit fixes it by using
`navigateToUrl` instead.

Before:

![Kapture 2020-09-16 at 16 19 11](https://user-images.githubusercontent.com/8509731/93342939-929f6c80-f838-11ea-9396-d514cad045b4.gif)
