### PR TITLE
[MF-284] Registration Submit Redirect Target should be Configurable

### DIFF
--- a/__mocks__/openmrs-esm-module-config.mock.tsx
+++ b/__mocks__/openmrs-esm-module-config.mock.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React from 'react';
 
 export const defineConfigSchema = jest.fn();
 
 export const validators = {
   isBoolean: jest.fn(),
-  isString: jest.fn()
+  isString: jest.fn(),
+  isUrlWithTemplateParameters: jest.fn(),
 };
 
 export const useConfig = jest.fn().mockReturnValue({
@@ -12,21 +13,21 @@ export const useConfig = jest.fn().mockReturnValue({
     enabled: true,
     list: [
       {
-        label: "SPA Page",
+        label: 'SPA Page',
         link: {
           spa: true,
-          url: "/some/route"
-        }
+          url: '/some/route',
+        },
       },
       {
-        label: "RefApp Page",
+        label: 'RefApp Page',
         link: {
           spa: false,
-          url: "/openmrs/some/route"
-        }
-      }
-    ]
-  }
+          url: '/openmrs/some/route',
+        },
+      },
+    ],
+  },
 });
 
-export const ModuleNameContext = React.createContext("fake-module-config");
+export const ModuleNameContext = React.createContext('fake-module-config');

--- a/src/config-schemas/openmrs-esm-patient-registration-schema.ts
+++ b/src/config-schemas/openmrs-esm-patient-registration-schema.ts
@@ -35,7 +35,7 @@ export const esmPatientRegistrationSchema = {
       },
     ],
   },
-  registrationSubimission: {
+  registrationSubmission: {
     afterCreateUrl: {
       default: '${openmrsSpaBase}/patient/${patientUuid}/chart',
       validators: [validators.isString],

--- a/src/config-schemas/openmrs-esm-patient-registration-schema.ts
+++ b/src/config-schemas/openmrs-esm-patient-registration-schema.ts
@@ -35,10 +35,10 @@ export const esmPatientRegistrationSchema = {
       },
     ],
   },
-  registrationSubmission: {
-    afterCreateUrl: {
+  links: {
+    submitButton: {
       default: '${openmrsSpaBase}/patient/${patientUuid}/chart',
-      validators: [validators.isString],
+      validators: [validators.isUrlWithTemplateParameters(['patientUuid'])],
     },
   },
 };

--- a/src/config-schemas/openmrs-esm-patient-registration-schema.ts
+++ b/src/config-schemas/openmrs-esm-patient-registration-schema.ts
@@ -35,4 +35,10 @@ export const esmPatientRegistrationSchema = {
       },
     ],
   },
+  registrationSubimission: {
+    afterCreateUrl: {
+      default: '${openmrsSpaBase}/patient/${patientUuid}/chart',
+      validators: [validators.isString],
+    },
+  },
 };

--- a/src/patient-registration/patient-registration.component.tsx
+++ b/src/patient-registration/patient-registration.component.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { Formik, Form } from 'formik';
 import { validationSchema as initialSchema } from './validation/patient-registration-validation';
 import { Patient, PatientIdentifierType, AttributeValue } from './patient-registration-helper';
@@ -107,7 +107,6 @@ interface AddressValidationSchemaType {
 
 export const PatientRegistration: React.FC = () => {
   const { search } = useLocation();
-  const history = useHistory();
   const config = useConfig();
   const [location, setLocation] = useState('');
   const [identifierTypes, setIdentifierTypes] = useState(new Array<PatientIdentifierType>());

--- a/src/patient-registration/patient-registration.component.tsx
+++ b/src/patient-registration/patient-registration.component.tsx
@@ -403,16 +403,10 @@ export const PatientRegistration: React.FC = () => {
     });
 
     const getAfterUrl = patientUuid => {
-      if (existingPatient) {
-        const afterEditUrl = new URLSearchParams(search).get('afterUrl');
-        if (afterEditUrl) {
-          return afterEditUrl;
-        }
-      }
-      const urlTemplate = config.registrationSubmission.afterCreateUrl;
-      return urlTemplate.includes('${patientUuid}')
-        ? interpolateString(urlTemplate, { patientUuid: patientUuid })
-        : urlTemplate;
+      return (
+        new URLSearchParams(search).get('afterUrl') ||
+        interpolateString(config.links.submitButton, { patientUuid: patientUuid })
+      );
     };
 
     // handle save patient

--- a/src/patient-registration/patient-registration.component.tsx
+++ b/src/patient-registration/patient-registration.component.tsx
@@ -410,7 +410,7 @@ export const PatientRegistration: React.FC = () => {
           return afterEditUrl;
         }
       }
-      const urlTemplate = config.registrationSubimission.afterCreateUrl;
+      const urlTemplate = config.registrationSubmission.afterCreateUrl;
       return urlTemplate.includes('${patientUuid}')
         ? interpolateString(urlTemplate, { patientUuid: patientUuid })
         : urlTemplate;


### PR DESCRIPTION
**Objectives**
- Implementers can configure where a user is redirected to on completing patient registration ✅ 

**How it works?**
This can be simply configured through `config.links.submitButton` in the esm-patient-registration's config schema whose default value is: '${openmrsSpaBase}/patient/${patientUuid}/chart'.

---
**Jira Ticket**
> https://issues.openmrs.org/browse/MF-284

**Child PRs**
- https://github.com/openmrs/openmrs-esm-patient-chart-widgets/pull/139