### PR TITLE
Changed the color of add icon from blue to white

### DIFF
--- a/src/add-patient-link.css
+++ b/src/add-patient-link.css
@@ -1,0 +1,3 @@
+svg.add-patient-color {
+  fill: #ffffff;
+}

--- a/src/add-patient-link.tsx
+++ b/src/add-patient-link.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ConfigurableLink } from '@openmrs/esm-framework';
 import Add20 from '@carbon/icons-react/es/add/20';
 import { HeaderGlobalAction } from 'carbon-components-react/es/components/UIShell';
-import './add-patient-link.css'
+import './add-patient-link.css';
 export default function Root() {
   return (
     <HeaderGlobalAction aria-label="Add" aria-labelledby="Add Patient" name="AddPatientIcon">

--- a/src/add-patient-link.tsx
+++ b/src/add-patient-link.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { ConfigurableLink } from '@openmrs/esm-framework';
 import Add20 from '@carbon/icons-react/es/add/20';
 import { HeaderGlobalAction } from 'carbon-components-react/es/components/UIShell';
-
+import './add-patient-link.css'
 export default function Root() {
   return (
     <HeaderGlobalAction aria-label="Add" aria-labelledby="Add Patient" name="AddPatientIcon">
       <ConfigurableLink to="${openmrsSpaBase}/patient-registration">
-        <Add20 />
+        <Add20 classname="add-patient-color" />
       </ConfigurableLink>
     </HeaderGlobalAction>
   );

--- a/src/add-patient-link.tsx
+++ b/src/add-patient-link.tsx
@@ -7,7 +7,7 @@ export default function Root() {
   return (
     <HeaderGlobalAction aria-label="Add" aria-labelledby="Add Patient" name="AddPatientIcon">
       <ConfigurableLink to="${openmrsSpaBase}/patient-registration">
-        <Add20 classname="add-patient-color" />
+        <Add20 className="add-patient-color" />
       </ConfigurableLink>
     </HeaderGlobalAction>
   );


### PR DESCRIPTION
Hi @FlorianRappl,
The default button rendered at the navigation bar was "blue" in color.

![image](https://user-images.githubusercontent.com/61249902/110643307-f8fabb80-81d9-11eb-9f42-86400dbf509a.png)

I have made a few changes to the file to make it white.
Do have a look and tell me if any other changes need to be made.
Thank you.
