### PR TITLE
MF-500: Added Edit Patient Details Button in the Patient Actions Menu

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,11 @@ function setupOpenMRS() {
         slot: 'top-nav-actions-slot',
         load: getAsyncLifecycle(() => import('./add-patient-link'), options),
       },
+      {
+        id: 'edit-patient-details-button',
+        slot: 'patient-actions-slot',
+        load: getAsyncLifecycle(() => import('./widgets/edit-patient-details-button.component'), options),
+      },
     ],
   };
 }

--- a/src/widgets/edit-patient-details-button.component.tsx
+++ b/src/widgets/edit-patient-details-button.component.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { ConfigurableLink } from '@openmrs/esm-framework';
+import { useTranslation } from 'react-i18next';
+
+export default function EditPatientDetailsButton({ patientUuid }) {
+  const { t } = useTranslation();
+  return (
+    <li className="bx--overflow-menu-options__option">
+      <ConfigurableLink
+        to={`\${openmrsSpaBase}/patient/${patientUuid}/edit`}
+        className="bx--overflow-menu-options__btn"
+        title={t('Edit Patient Details', 'Edit Patient Details')}>
+        <span className="bx--overflow-menu-options__option-content">
+          {t('Edit Patient Details', 'Edit Patient Details')}
+        </span>
+      </ConfigurableLink>
+    </li>
+  );
+}


### PR DESCRIPTION
**What does this PR do?**
It adds the `Edit Patient Details` button in the Patient Actions Menu as shown in the image below.
![image](https://user-images.githubusercontent.com/51502471/115608259-ab5a8e00-a303-11eb-9b00-eebbef72f46e.png)
