### PR TITLE
Restore original form section header names

### DIFF
--- a/src/config-schemas/openmrs-esm-patient-registration-schema.ts
+++ b/src/config-schemas/openmrs-esm-patient-registration-schema.ts
@@ -27,10 +27,10 @@ export const esmPatientRegistrationSchema = {
       },
     },
     _default: {
-      demographics: { name: 'basicInfoSectionName', fields: ['name', 'gender', 'dob', 'id'] },
-      contact: { name: 'contactDetailsSectionName', fields: ['address', 'phone', 'email'] },
-      death: { name: 'deathInfoSectionName', fields: ['death'] },
-      relationships: { name: 'relationshipsSectionName' },
+      demographics: { name: 'Basic Info', fields: ['name', 'gender', 'dob', 'id'] },
+      contact: { name: 'Contact Details', fields: ['address', 'phone', 'email'] },
+      death: { name: 'Death Info', fields: ['death'] },
+      relationships: { name: 'Relationships' },
     },
   },
   fieldDefinitions: {
@@ -57,7 +57,7 @@ export const esmPatientRegistrationSchema = {
     },
     _default: {
       phone: {
-        label: 'Telophone Number',
+        label: 'Telephone Number',
         uuid: '14d4f066-15f5-102d-96e4-000c29c2a5d7',
         validation: { required: true, matches: '^[0-9]*$' },
       },


### PR DESCRIPTION
These got borked by https://github.com/openmrs/openmrs-esm-patient-registration/pull/101. The way the translations were set up to work for the section header names was less than ideal and would certainly not work with the new approach we're using to extract translation strings. So I've restored them back to their original untranslated forms for now. I've also fixed a mistyped label for `Telephone number`.

Restores this:

![Screenshot 2021-05-10 at 09 29 29](https://user-images.githubusercontent.com/8509731/117615488-760ec680-b172-11eb-8a10-2b2d0154fcd8.png)

to this:

![Screenshot 2021-05-10 at 09 29 47](https://user-images.githubusercontent.com/8509731/117615478-7313d600-b172-11eb-9c4b-9e70db53089d.png)

